### PR TITLE
Implement signup route error cases

### DIFF
--- a/auth-service/src/domain/error.rs
+++ b/auth-service/src/domain/error.rs
@@ -1,0 +1,7 @@
+pub enum AuthAPIError {
+    UserAlreadyExists,
+    InvalidCredentials,
+    UnexpectedError,
+}
+
+

--- a/auth-service/src/domain/mod.rs
+++ b/auth-service/src/domain/mod.rs
@@ -1,3 +1,5 @@
 mod user;
+mod error;
 
 pub use user::*;
+pub use error::*;

--- a/auth-service/src/lib.rs
+++ b/auth-service/src/lib.rs
@@ -1,18 +1,41 @@
 use std::error::Error;
 use axum::{
-    response::IntoResponse,
+    response::{IntoResponse, Response},
     routing::{get, post},
     serve::Serve, Router,
-    http::StatusCode
+    http::StatusCode,
+    Json
 };
 use tower_http::services::ServeDir;
 use app_state::AppState;
+use domain::AuthAPIError;
+use serde::{Deserialize, Serialize};
 
 pub mod routes;
 pub mod services;
 pub mod domain;
 pub mod app_state;
 
+#[derive(Serialize, Deserialize)]
+pub struct ErrorResponse {
+    pub error: String,
+}
+
+impl IntoResponse for AuthAPIError {
+    fn into_response(self) -> Response {
+        let (status, error_message) = match self {
+            AuthAPIError::UserAlreadyExists => (StatusCode::CONFLICT, "User already exists"),
+            AuthAPIError::InvalidCredentials => (StatusCode::BAD_REQUEST, "Invalid credentials"),
+            AuthAPIError::UnexpectedError => (StatusCode::INTERNAL_SERVER_ERROR, "Uexpected error")
+        };
+
+        let body = Json(ErrorResponse {
+            error: error_message.to_string(),
+        });
+    
+        (status, body).into_response()
+    }
+}
 
 pub struct Application {
     server: Serve<Router, Router>,

--- a/auth-service/src/routes/signup.rs
+++ b/auth-service/src/routes/signup.rs
@@ -2,7 +2,7 @@ use axum::{http::StatusCode, extract::State,
     response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};
 
-use crate::{app_state::AppState, domain::User};
+use crate::{app_state::AppState, domain::{AuthAPIError, User}, services::UserStoreError};
 #[derive(Deserialize)]
 pub struct SignupRequest {
     pub email:String,
@@ -16,16 +16,27 @@ pub struct SignupResponse {
     pub message: String
 }
 
-pub async fn signup(State(state): State<AppState>, Json(request): Json<SignupRequest>) -> impl IntoResponse {
-    let user = User::new(request.email, request.password, request.requires_2fa);
+pub async fn signup(State(state): State<AppState>, Json(request): Json<SignupRequest>) -> Result<impl IntoResponse, AuthAPIError> {
+    let email = request.email;
+    let password = request.password;
+
+    if email.is_empty() || !email.contains("@") || password.trim().to_string().capacity() < 8 || email.trim().to_string().capacity() <= 1 {
+        return Err(AuthAPIError::InvalidCredentials);
+    }
+
+    let user = User::new(email, password, request.requires_2fa);
 
     let mut user_store = state.user_store.write().await;
 
-    user_store.add_user(user).unwrap();
-
-    let response = Json(SignupResponse {
-        message: "User created successfully!".to_string()
-    });
-    
-    (StatusCode::CREATED, response)
+    match user_store.add_user(user) {
+        Ok(()) => {
+            let response = Json(SignupResponse {
+                message: "User created successfully!".to_string()
+            });
+            
+            Ok((StatusCode::CREATED, response))
+        },
+        Err(UserStoreError::UserAlreadyExists) => Err(AuthAPIError::UserAlreadyExists),
+        Err(_) => Err(AuthAPIError::UnexpectedError),
+    }
 }

--- a/auth-service/tests/api/signup.rs
+++ b/auth-service/tests/api/signup.rs
@@ -71,3 +71,69 @@ async fn should_return_201_if_valid_input() {
     );
 }
 
+#[tokio::test]
+async fn should_return_400_if_invalid_input() {
+    let app = TestApp::new().await;
+
+    let test_cases = [
+        serde_json::json!({
+            "email": "user.mail.com",
+            "password": "password123",
+            "requires2FA": false
+        }),
+        serde_json::json!({
+            "email": "",
+            "password": "password123",
+            "requires2FA": true 
+        }),
+        serde_json::json!({
+            "email": "user_test@mail.com",
+            "password": "          ",
+            "requires2FA": true
+        }),
+        serde_json::json!({
+            "email": "user_test@mail.com",
+            "password": "pass",
+            "requires2FA": true
+        }),
+        serde_json::json!({
+            "email": "user_test@mail.com",
+            "password": "",
+            "requires2FA": true
+        })
+    ];
+
+    for test_case in test_cases.iter() {
+        let response = app.signup(&test_case).await;
+
+        assert_eq!(
+            response.status().as_u16(),
+            400,
+            "Failed for input: {:?}",
+            test_case
+        )
+    }
+}
+#[tokio::test]
+async fn should_return_409_if_email() {
+    let app = TestApp::new().await;
+    let random_email = helpers::get_random_email();
+
+
+    let test_case = serde_json::json!({
+        "email": random_email,
+        "password": "password123",
+        "requires2FA": true
+    });
+
+    app.signup(&test_case).await;
+
+    let response = app.signup(&test_case).await;
+
+    assert_eq!(
+        response.status().as_u16(),
+        409,
+        "Failed for input: {:?}",
+        test_case
+    )
+}

--- a/auth-service/tests/api/signup.rs
+++ b/auth-service/tests/api/signup.rs
@@ -1,5 +1,5 @@
 use crate::helpers::{self, TestApp};
-use auth_service::routes::SignupResponse;
+use auth_service::{routes::SignupResponse, ErrorResponse};
 
 #[tokio::test]
 async fn should_return_422_if_malformed_input() {
@@ -47,7 +47,7 @@ async fn should_return_201_if_valid_input() {
 
     let valid_data = serde_json::json!({
         "email": random_email,
-        "password": "string",
+        "password": "string1234",
         "requires2FA": true
     });
 
@@ -100,6 +100,11 @@ async fn should_return_400_if_invalid_input() {
             "email": "user_test@mail.com",
             "password": "",
             "requires2FA": true
+        }),
+        serde_json::json!({
+            "email": "    @      ",
+            "password": "password1233",
+            "requires2FA": true
         })
     ];
 
@@ -111,6 +116,15 @@ async fn should_return_400_if_invalid_input() {
             400,
             "Failed for input: {:?}",
             test_case
+        );
+
+        assert_eq!(
+            response
+                .json::<ErrorResponse>()
+                .await
+                .expect("Could not deserialize response body to ErrorResponse")
+                .error,
+                "Invalid credentials".to_owned()
         )
     }
 }
@@ -135,5 +149,14 @@ async fn should_return_409_if_email() {
         409,
         "Failed for input: {:?}",
         test_case
+    );
+
+    assert_eq!(
+        response
+            .json::<ErrorResponse>()
+            .await
+            .expect("Could not deserialize response body to ErrorResponse")
+            .error,
+            "User already exists".to_owned()
     )
 }


### PR DESCRIPTION
#### What does this PR do?
- This adds tests for cases resulting in a 409, 400 and 500 when signing up a user
- Adds functionality to handle those edge cases